### PR TITLE
Generation of HTML reports

### DIFF
--- a/examples/calculator/calculator.cpp
+++ b/examples/calculator/calculator.cpp
@@ -42,7 +42,6 @@ int main()
 		});
 
 	auto report = p.prepare();
-	p.generate_html_report("calculator.html");
 	if (!report)
 	{
 		fmt::print("{}\n", report.to_string());

--- a/examples/calculator/calculator.cpp
+++ b/examples/calculator/calculator.cpp
@@ -41,7 +41,9 @@ int main()
 			return -args[1];
 		});
 
-	if (auto report = p.prepare(); !report)
+	auto report = p.prepare();
+	p.generate_html_report("calculator.html");
+	if (!report)
 	{
 		fmt::print("{}\n", report.to_string());
 		return 1;

--- a/include/pog/automaton.h
+++ b/include/pog/automaton.h
@@ -117,7 +117,7 @@ public:
 		}
 	}
 
-	std::string generate_graph()
+	std::string generate_graph() const
 	{
 		std::vector<std::string> states_str(_states.size());
 		std::transform(_states.begin(), _states.end(), states_str.begin(), [](const auto& state) {

--- a/include/pog/grammar.h
+++ b/include/pog/grammar.h
@@ -32,6 +32,26 @@ public:
 	const SymbolType* get_end_of_input_symbol() const { return _internal_end_of_input; }
 	const RuleType* get_start_rule() const { return _start_rule; }
 
+	std::vector<const SymbolType*> get_terminal_symbols() const
+	{
+		std::vector<const SymbolType*> result;
+		transform_if(_symbols.begin(), _symbols.end(), std::back_inserter(result),
+			[](const auto& s) { return s->is_terminal() || s->is_end(); },
+			[](const auto& s) { return s.get(); }
+		);
+		return result;
+	}
+
+	std::vector<const SymbolType*> get_nonterminal_symbols() const
+	{
+		std::vector<const SymbolType*> result;
+		transform_if(_symbols.begin(), _symbols.end(), std::back_inserter(result),
+			[](const auto& s) { return s->is_nonterminal(); },
+			[](const auto& s) { return s.get(); }
+		);
+		return result;
+	}
+
 	SymbolType* get_symbol(const std::string& name) const
 	{
 		auto itr = _name_to_symbol.find(name);

--- a/include/pog/html_report.h
+++ b/include/pog/html_report.h
@@ -2,8 +2,7 @@
 
 #include <fstream>
 
-#include <pog/grammar.h>
-#include <pog/parsing_table.h>
+#include <pog/parser.h>
 
 namespace pog {
 
@@ -11,31 +10,36 @@ template <typename ValueT>
 class HtmlReport
 {
 public:
-	using AutomatonType = Automaton<ValueT>;
-	using GrammarType = Grammar<ValueT>;
-	using ParsingTableType = ParsingTable<ValueT>;
+	using ParserType = Parser<ValueT>;
 
 	using ShiftActionType = Shift<ValueT>;
 	using ReduceActionType = Reduce<ValueT>;
 
-	HtmlReport(const GrammarType* grammar, const AutomatonType* automaton, const ParsingTableType* parsing_table)
-		: _grammar(grammar), _automaton(automaton), _parsing_table(parsing_table) {}
+	HtmlReport(const ParserType& parser) : _parser(parser) {}
 
 	void save(const std::string& file_path)
 	{
 		static const std::string html_page_template = R"(<!doctype html>
 <html lang="en">
 	<head>
+		<meta charset="UTF-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 		<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
 		<link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
 		<style>
-			#parsing_table {{
+			#parsing-table {{
 				width: auto;
 			}}
-			#parsing_table td, #parsing_table th {{
+			#parsing-table td, #parsing-table th {{
 				min-width: 2em;
 				max-width: 6em;
+				word-wrap: break-word;
+				text-align: center;
+			}}
+			.state-table {{
+				width: auto;
+			}}
+			.state-table td, .state-table th {{
 				word-wrap: break-word;
 				text-align: center;
 			}}
@@ -45,46 +49,78 @@ public:
 		<nav class="navbar navbar-dark bg-dark">
 			<span class="navbar-brand">pog report</span>
 		</nav>
-		<div class="container">
-			<div class="pt-3 row justify-content-md-center">
-				<table id="parsing_table" class="table table-bordered">
-					<thead class="thead-dark">
-						<tr>
-							<th style="text-align: center" rowspan="2">State</th>
-							<th style="text-align: center" colspan="{number_of_terminals}">Action</th>
-							<th style="text-align: center" colspan="{number_of_nonterminals}">Goto</th>
-						</tr>
-						<tr>
-							{symbols}
-						</tr>
-					</thead>
-					<tbody>
-						{rows}
-					</tbody>
-				</table>
-			</div>
-			<div class="pt-3 row justify-content-md-center">
-				{states}
-			</div>
-			<div class="pt-3 row justify-content-md-center">
+		<main class="container">
+			{issues}
+			{parsing_table}
+			{states}
+			{automaton}
+			<div class="pt-3 row justify-content-center">
 				<small>Generated: {generated_at}</small>
 			</div>
 		</div>
-		<script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+		<script src="https://code.jquery.com/jquery-3.4.1.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
 		<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.4/clipboard.min.js"></script>
 		<script type="text/javascript">
 $(document).ready(function() {{
 	$('[data-toggle="tooltip"]').tooltip();
 }});
+
+var clipboard = new ClipboardJS('.btn');
 		</script>
 	</body>
 </html>)";
 
 		using namespace fmt;
 
-		auto terminal_symbols = _grammar->get_terminal_symbols();
-		auto nonterminal_symbols = _grammar->get_nonterminal_symbols();
+		std::ofstream file(file_path, std::ios::out | std::ios::trunc);
+		if (file.is_open())
+			file << fmt::format(html_page_template,
+				"issues"_a = build_issues(),
+				"parsing_table"_a = build_parsing_table(),
+				"states"_a = build_states(),
+				"automaton"_a = generate_automaton_graph(),
+				"generated_at"_a = current_time("%Y-%m-%d %H:%M:%S %Z")
+			);
+		file.close();
+	}
+
+private:
+	std::string build_issues()
+	{
+		using namespace fmt;
+
+		if (_parser._report)
+			return std::string{};
+
+		std::vector<std::string> issues(_parser._report.number_of_issues());
+		std::transform(_parser._report.begin(), _parser._report.end(), issues.begin(), [](const auto& issue) {
+			return fmt::format("<li><span>{}</span></li>", visit_with(issue,
+				[&](const ShiftReduceConflict<ValueT>& sr) { return sr.to_string("→", "ε"); },
+				[&](const ReduceReduceConflict<ValueT>& rr) { return rr.to_string("→", "ε"); }
+			));
+		});
+
+		return fmt::format(
+			R"(<div class="pt-3 row justify-content-center">
+				<div class="col-12 alert alert-danger">
+					<h3 class="font-weight-bold">Issues</h3>
+					<ul>
+						{issues}
+					</ul>
+				</div>
+			</div>)",
+			"issues"_a = fmt::join(issues.begin(), issues.end(), "")
+		);
+	}
+
+	std::string build_parsing_table()
+	{
+		using namespace fmt;
+
+		auto terminal_symbols = _parser._grammar.get_terminal_symbols();
+		auto nonterminal_symbols = _parser._grammar.get_nonterminal_symbols();
 
 		std::vector<std::string> symbol_headers(terminal_symbols.size() + nonterminal_symbols.size());
 		std::transform(terminal_symbols.begin(), terminal_symbols.end(), symbol_headers.begin(), [](const auto& s) {
@@ -94,8 +130,8 @@ $(document).ready(function() {{
 			return fmt::format("<th>{}</th>", s->get_name());
 		});
 
-		std::vector<std::string> rows(_automaton->get_states().size());
-		for (const auto& state : _automaton->get_states())
+		std::vector<std::string> rows(_parser._automaton.get_states().size());
+		for (const auto& state : _parser._automaton.get_states())
 		{
 			std::vector<std::string> row;
 			row.push_back(fmt::format(
@@ -105,7 +141,7 @@ $(document).ready(function() {{
 			));
 			for (const auto& sym : terminal_symbols)
 			{
-				auto action = _parsing_table->get_action(state.get(), sym);
+				auto action = _parser._parsing_table.get_action(state.get(), sym);
 				if (!action)
 				{
 					row.push_back("<td></td>");
@@ -115,9 +151,9 @@ $(document).ready(function() {{
 				row.push_back(visit_with(action.value(),
 					[](const ShiftActionType& shift) {
 						return fmt::format(
-							"<td data-toggle=\"tooltip\" data-placement=\"bottom\" title=\"{}\" data-html=\"true\">s{}</td>",
-							shift.state->to_string("→", "ε", "•", "<br/>"),
-							shift.state->get_index()
+							"<td data-toggle=\"tooltip\" data-placement=\"bottom\" title=\"{state_str}\" data-html=\"true\"><a href=\"#state{state_id}\">s{state_id}</a></td>",
+							"state_str"_a = shift.state->to_string("→", "ε", "•", "<br/>"),
+							"state_id"_a = shift.state->get_index()
 						);
 					},
 					[](const ReduceActionType& reduce) {
@@ -133,7 +169,7 @@ $(document).ready(function() {{
 
 			for (const auto& sym : nonterminal_symbols)
 			{
-				auto go_to = _parsing_table->get_transition(state.get(), sym);
+				auto go_to = _parser._parsing_table.get_transition(state.get(), sym);
 				if (!go_to)
 				{
 					row.push_back("<td></td>");
@@ -141,9 +177,9 @@ $(document).ready(function() {{
 				}
 
 				row.push_back(fmt::format(
-					"<td data-toggle=\"tooltip\" data-placement=\"bottom\" title=\"{}\" data-html=\"true\">{}</td>",
-					go_to.value()->to_string("→", "ε", "•", "<br/>"),
-					go_to.value()->get_index()
+					"<td data-toggle=\"tooltip\" data-placement=\"bottom\" title=\"{state_str}\" data-html=\"true\"><a href=\"#state{state_id}\">{state_id}</a></td>",
+					"state_str"_a = go_to.value()->to_string("→", "ε", "•", "<br/>"),
+					"state_id"_a = go_to.value()->get_index()
 				));
 			}
 
@@ -151,23 +187,98 @@ $(document).ready(function() {{
 			rows.push_back(fmt::format("{}", fmt::join(row.begin(), row.end(), "")));
 		}
 
-		std::ofstream file(file_path, std::ios::out | std::ios::trunc);
-		if (file.is_open())
-			file << fmt::format(html_page_template,
-				"number_of_terminals"_a = fmt::format("{}", terminal_symbols.size()),
-				"number_of_nonterminals"_a = fmt::format("{}", nonterminal_symbols.size()),
-				"symbols"_a = fmt::format("{}", fmt::join(symbol_headers.begin(), symbol_headers.end(), "")),
-				"rows"_a = fmt::format("{}", fmt::join(rows.begin(), rows.end(), "\n")),
-				"states"_a = "HERE COME STATES",
-				"generated_at"_a = current_time("%Y-%m-%d %H:%M:%S %Z")
-			);
-		file.close();
+		return fmt::format(
+			R"(<div class="pt-3 row justify-content-center">
+				<h3 class="col text-center">Parsing Table</h3>
+				<div class="w-100"></div>
+				<div class="col">
+					<table id="parsing-table" class="table table-bordered table-sm ml-auto mr-auto">
+						<thead class="thead-dark">
+							<tr>
+								<th rowspan="2">State</th>
+								<th colspan="{number_of_terminals}">Action</th>
+								<th colspan="{number_of_nonterminals}">Goto</th>
+							</tr>
+							<tr>
+								{symbols}
+							</tr>
+						</thead>
+						<tbody>
+							{rows}
+						</tbody>
+					</table>
+				</div>
+			</div>)",
+			"number_of_terminals"_a = terminal_symbols.size(),
+			"number_of_nonterminals"_a = nonterminal_symbols.size(),
+			"symbols"_a = fmt::join(symbol_headers.begin(), symbol_headers.end(), ""),
+			"rows"_a = fmt::join(rows.begin(), rows.end(), "")
+		);
 	}
 
-private:
-	const GrammarType* _grammar;
-	const AutomatonType* _automaton;
-	const ParsingTableType* _parsing_table;
+	std::string build_states()
+	{
+		using namespace fmt;
+
+		static const std::string single_state_template =
+			R"(<div class="col-4">
+				<table class="state-table table table-bordered table-sm ml-auto mr-auto" id="state{id}">
+					<thead class="thead-dark">
+						<tr><th>State {id}</th></tr>
+					</thead>
+					<tbody>
+						{rows}
+					<tbody>
+				</table>
+			</div>)";
+
+		std::vector<std::string> states;
+		for (const auto& state : _parser._automaton.get_states())
+		{
+			std::vector<std::string> cols(state->size());
+			std::transform(state->begin(), state->end(), cols.begin(), [](const auto& item) {
+				return fmt::format("<tr><td>{}</td></tr>", item->to_string("→", "ε", "•"));
+			});
+			states.push_back(fmt::format(
+				single_state_template,
+				"id"_a = state->get_index(),
+				"rows"_a = fmt::join(cols.begin(), cols.end(), "")
+			));
+		}
+
+		return fmt::format(
+			R"(<div class="row justify-content-around">
+				<h3 class="col text-center">States</h3>
+				<div class="w-100"></div>
+				{states}
+			</div>)",
+			"states"_a = fmt::join(states.begin(), states.end(), "")
+		);
+	}
+
+	std::string generate_automaton_graph()
+	{
+		using namespace fmt;
+
+		return fmt::format(R"(<div class="row justify-content-center">
+				<h3 class="col text-center">Automaton (graphviz)</h3>
+				<div class="w-100"></div>
+				<textarea id="automaton" class="textarea form-control text-monospace" style="height: 20em; resize: none; font-size: 12px;" readonly>{automaton}</textarea>
+				<div class="w-100"></div>
+				<div class="col pt-2 text-center">
+					<button class="btn btn-dark" data-clipboard-target="#automaton">
+						Copy
+					</button>
+				</div>
+			</div>)",
+			"automaton"_a = _parser._automaton.generate_graph()
+		);
+	}
+
+	const ParserType& _parser;
 };
+
+template <typename ValueT>
+HtmlReport(const Parser<ValueT>&) -> HtmlReport<ValueT>;
 
 } // namespace pog

--- a/include/pog/html_report.h
+++ b/include/pog/html_report.h
@@ -1,0 +1,173 @@
+#pragma once
+
+#include <fstream>
+
+#include <pog/grammar.h>
+#include <pog/parsing_table.h>
+
+namespace pog {
+
+template <typename ValueT>
+class HtmlReport
+{
+public:
+	using AutomatonType = Automaton<ValueT>;
+	using GrammarType = Grammar<ValueT>;
+	using ParsingTableType = ParsingTable<ValueT>;
+
+	using ShiftActionType = Shift<ValueT>;
+	using ReduceActionType = Reduce<ValueT>;
+
+	HtmlReport(const GrammarType* grammar, const AutomatonType* automaton, const ParsingTableType* parsing_table)
+		: _grammar(grammar), _automaton(automaton), _parsing_table(parsing_table) {}
+
+	void save(const std::string& file_path)
+	{
+		static const std::string html_page_template = R"(<!doctype html>
+<html lang="en">
+	<head>
+		<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+		<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+		<link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
+		<style>
+			#parsing_table {{
+				width: auto;
+			}}
+			#parsing_table td, #parsing_table th {{
+				min-width: 2em;
+				max-width: 6em;
+				word-wrap: break-word;
+				text-align: center;
+			}}
+		</style>
+	</head>
+	<body>
+		<nav class="navbar navbar-dark bg-dark">
+			<span class="navbar-brand">pog report</span>
+		</nav>
+		<div class="container">
+			<div class="pt-3 row justify-content-md-center">
+				<table id="parsing_table" class="table table-bordered">
+					<thead class="thead-dark">
+						<tr>
+							<th style="text-align: center" rowspan="2">State</th>
+							<th style="text-align: center" colspan="{number_of_terminals}">Action</th>
+							<th style="text-align: center" colspan="{number_of_nonterminals}">Goto</th>
+						</tr>
+						<tr>
+							{symbols}
+						</tr>
+					</thead>
+					<tbody>
+						{rows}
+					</tbody>
+				</table>
+			</div>
+			<div class="pt-3 row justify-content-md-center">
+				{states}
+			</div>
+			<div class="pt-3 row justify-content-md-center">
+				<small>Generated: {generated_at}</small>
+			</div>
+		</div>
+		<script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
+		<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
+		<script type="text/javascript">
+$(document).ready(function() {{
+	$('[data-toggle="tooltip"]').tooltip();
+}});
+		</script>
+	</body>
+</html>)";
+
+		using namespace fmt;
+
+		auto terminal_symbols = _grammar->get_terminal_symbols();
+		auto nonterminal_symbols = _grammar->get_nonterminal_symbols();
+
+		std::vector<std::string> symbol_headers(terminal_symbols.size() + nonterminal_symbols.size());
+		std::transform(terminal_symbols.begin(), terminal_symbols.end(), symbol_headers.begin(), [](const auto& s) {
+			return fmt::format("<th>{}</th>", s->get_name());
+		});
+		std::transform(nonterminal_symbols.begin(), nonterminal_symbols.end(), symbol_headers.begin() + terminal_symbols.size(), [](const auto& s) {
+			return fmt::format("<th>{}</th>", s->get_name());
+		});
+
+		std::vector<std::string> rows(_automaton->get_states().size());
+		for (const auto& state : _automaton->get_states())
+		{
+			std::vector<std::string> row;
+			row.push_back(fmt::format(
+				"<tr><td data-toggle=\"tooltip\" data-placement=\"bottom\" title=\"{}\" data-html=\"true\">{}</td>",
+				state->to_string("→", "ε", "•", "<br/>"),
+				state->get_index()
+			));
+			for (const auto& sym : terminal_symbols)
+			{
+				auto action = _parsing_table->get_action(state.get(), sym);
+				if (!action)
+				{
+					row.push_back("<td></td>");
+					continue;
+				}
+
+				row.push_back(visit_with(action.value(),
+					[](const ShiftActionType& shift) {
+						return fmt::format(
+							"<td data-toggle=\"tooltip\" data-placement=\"bottom\" title=\"{}\" data-html=\"true\">s{}</td>",
+							shift.state->to_string("→", "ε", "•", "<br/>"),
+							shift.state->get_index()
+						);
+					},
+					[](const ReduceActionType& reduce) {
+						return fmt::format(
+							"<td data-toggle=\"tooltip\" data-placement=\"bottom\" title=\"{}\">r{}</td>",
+							reduce.rule->to_string("→", "ε"),
+							reduce.rule->get_index()
+						);
+					},
+					[](const Accept&) -> std::string { return "<td><span class=\"fa fa-check-square\" style=\"color: green\"/></td>"; }
+				));
+			}
+
+			for (const auto& sym : nonterminal_symbols)
+			{
+				auto go_to = _parsing_table->get_transition(state.get(), sym);
+				if (!go_to)
+				{
+					row.push_back("<td></td>");
+					continue;
+				}
+
+				row.push_back(fmt::format(
+					"<td data-toggle=\"tooltip\" data-placement=\"bottom\" title=\"{}\" data-html=\"true\">{}</td>",
+					go_to.value()->to_string("→", "ε", "•", "<br/>"),
+					go_to.value()->get_index()
+				));
+			}
+
+			row.push_back("</tr>");
+			rows.push_back(fmt::format("{}", fmt::join(row.begin(), row.end(), "")));
+		}
+
+		std::ofstream file(file_path, std::ios::out | std::ios::trunc);
+		if (file.is_open())
+			file << fmt::format(html_page_template,
+				"number_of_terminals"_a = fmt::format("{}", terminal_symbols.size()),
+				"number_of_nonterminals"_a = fmt::format("{}", nonterminal_symbols.size()),
+				"symbols"_a = fmt::format("{}", fmt::join(symbol_headers.begin(), symbol_headers.end(), "")),
+				"rows"_a = fmt::format("{}", fmt::join(rows.begin(), rows.end(), "\n")),
+				"states"_a = "HERE COME STATES",
+				"generated_at"_a = current_time("%Y-%m-%d %H:%M:%S %Z")
+			);
+		file.close();
+	}
+
+private:
+	const GrammarType* _grammar;
+	const AutomatonType* _automaton;
+	const ParsingTableType* _parsing_table;
+};
+
+} // namespace pog

--- a/include/pog/parser.h
+++ b/include/pog/parser.h
@@ -7,6 +7,7 @@
 #include <pog/automaton.h>
 #include <pog/errors.h>
 #include <pog/grammar.h>
+#include <pog/html_report.h>
 #include <pog/parser_report.h>
 #include <pog/parsing_table.h>
 #include <pog/rule_builder.h>
@@ -196,6 +197,12 @@ public:
 	std::string generate_includes_relation_graph()
 	{
 		return _includes.generate_relation_graph();
+	}
+
+	void generate_html_report(const std::string& file_path) const
+	{
+		HtmlReport html_report(&_grammar, &_automaton, &_parsing_table);
+		html_report.save(file_path);
 	}
 
 private:

--- a/include/pog/parser_report.h
+++ b/include/pog/parser_report.h
@@ -15,9 +15,9 @@ struct ShiftReduceConflict
 	const Symbol<ValueT>* symbol;
 	const Rule<ValueT>* rule;
 
-	std::string to_string() const
+	std::string to_string(std::string_view arrow = "->", std::string_view eps = "<eps>") const
 	{
-		return fmt::format("Shift-reduce conflict of symbol \'{}\' and rule \'{}\' in state {}", symbol->get_name(), rule->to_string(), state->get_index());
+		return fmt::format("Shift-reduce conflict of symbol \'{}\' and rule \'{}\' in state {}", symbol->get_name(), rule->to_string(arrow, eps), state->get_index());
 	}
 };
 
@@ -28,9 +28,9 @@ struct ReduceReduceConflict
 	const Rule<ValueT>* rule1;
 	const Rule<ValueT>* rule2;
 
-	std::string to_string() const
+	std::string to_string(std::string_view arrow = "->", std::string_view eps = "<eps>") const
 	{
-		return fmt::format("Reduce-reduce conflict of rule \'{}\' and rule \'{}\' in state {}", rule1->to_string(), rule2->to_string(), state->get_index());
+		return fmt::format("Reduce-reduce conflict of rule \'{}\' and rule \'{}\' in state {}", rule1->to_string(arrow, eps), rule2->to_string(arrow, eps), state->get_index());
 	}
 };
 
@@ -68,13 +68,13 @@ public:
 		_issues.push_back(ReduceReduceConflictType{state, rule1, rule2});
 	}
 
-	std::string to_string() const
+	std::string to_string(std::string_view arrow = "->", std::string_view eps = "<eps>") const
 	{
 		std::vector<std::string> issues_str(_issues.size());
-		std::transform(_issues.begin(), _issues.end(), issues_str.begin(), [](const auto& issue) {
+		std::transform(_issues.begin(), _issues.end(), issues_str.begin(), [&](const auto& issue) {
 			return visit_with(issue,
-				[](const ShiftReduceConflictType& sr) { return sr.to_string(); },
-				[](const ReduceReduceConflictType& rr) { return rr.to_string(); }
+				[&](const ShiftReduceConflictType& sr) { return sr.to_string(arrow, eps); },
+				[&](const ReduceReduceConflictType& rr) { return rr.to_string(arrow, eps); }
 			);
 		});
 		return fmt::format("{}", fmt::join(issues_str.begin(), issues_str.end(), "\n"));

--- a/include/pog/state.h
+++ b/include/pog/state.h
@@ -70,7 +70,7 @@ public:
 			}) == 1;
 	}
 
-	std::string to_string(std::string_view arrow = "->", std::string_view eps = "<eps>", std::string_view sep = "<*>", std::string_view newline = "\n") const
+	std::string to_string(std::string_view arrow = "->", std::string_view eps = "<eps>", std::string_view sep = "<*>", const std::string& newline = "\n") const
 	{
 		std::vector<std::string> item_strings(_items.size());
 		std::transform(_items.begin(), _items.end(), item_strings.begin(), [&](const auto& item) {

--- a/include/pog/state.h
+++ b/include/pog/state.h
@@ -70,13 +70,13 @@ public:
 			}) == 1;
 	}
 
-	std::string to_string(std::string_view arrow = "->", std::string_view eps = "<eps>", std::string_view sep = "<*>") const
+	std::string to_string(std::string_view arrow = "->", std::string_view eps = "<eps>", std::string_view sep = "<*>", std::string_view newline = "\n") const
 	{
 		std::vector<std::string> item_strings(_items.size());
 		std::transform(_items.begin(), _items.end(), item_strings.begin(), [&](const auto& item) {
 			return item->to_string(arrow, eps, sep);
 		});
-		return fmt::format("{}", fmt::join(item_strings.begin(), item_strings.end(), "\n"));
+		return fmt::format("{}", fmt::join(item_strings.begin(), item_strings.end(), newline));
 	}
 
 	std::vector<const ItemType*> get_production_items() const

--- a/include/pog/utils.h
+++ b/include/pog/utils.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <ctime>
 #include <functional>
+#include <iomanip>
+#include <sstream>
 #include <variant>
 #include <utility>
 
@@ -56,6 +59,17 @@ auto visit_with(Variant& v, Fs&&... fs)
 	return std::visit(overloaded{
 		std::forward<Fs>(fs)...
 	}, v);
+}
+
+template <typename FormatT>
+inline std::string current_time(FormatT&& format)
+{
+	auto now = std::time(nullptr);
+	auto tm = std::localtime(&now);
+
+	std::ostringstream ss;
+	ss << std::put_time(tm, std::forward<FormatT>(format));
+	return ss.str();
 }
 
 } // namespace pog


### PR DESCRIPTION
You can now use `HtmlReport` class to generate HTML report of your parser. It includes

* reporting of issues with grammar (shift-reduce, reduce-reduce)
* parsing table
* states and their items
* graphviz representation of LR automaton

This is also test if pull requests build using TravisCI.