### PR TITLE
Various fixes

### DIFF
--- a/include/pog/parser.h
+++ b/include/pog/parser.h
@@ -99,6 +99,16 @@ public:
 		_grammar.set_start_symbol(_grammar.add_symbol(SymbolKind::Nonterminal, name));
 	}
 
+	void push_input_stream(std::istream& input)
+	{
+		_tokenizer.push_input_stream(input);
+	}
+
+	void pop_input_stream()
+	{
+		_tokenizer.pop_input_stream();
+	}
+
 	std::optional<ValueT> parse(std::istream& input)
 	{
 		std::optional<TokenMatchType> token;

--- a/include/pog/pog.h
+++ b/include/pog/pog.h
@@ -2,4 +2,5 @@
 
 #define POG_VERSION "0.1.0"
 
+#include <pog/html_report.h>
 #include <pog/parser.h>

--- a/include/pog/token_builder.h
+++ b/include/pog/token_builder.h
@@ -27,7 +27,7 @@ public:
 		if (!_end_token)
 		{
 			auto* symbol = !_symbol_name.empty() ? _grammar->add_symbol(SymbolKind::Terminal, _symbol_name) : nullptr;
-			token = _tokenizer->add_token(_fullword ? fmt::format("\\b{}(\\b|$)", _pattern) : _pattern, symbol, _in_states);
+			token = _tokenizer->add_token(_fullword ? fmt::format("{}(\\b|$)", _pattern) : _pattern, symbol, _in_states);
 			if (symbol && _precedence)
 			{
 				const auto& prec = _precedence.value();

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -624,3 +624,48 @@ function z {
 	EXPECT_EQ(defs, (std::unordered_set<std::string>{"x", "y", "z", "a"}));
 	EXPECT_EQ(redefs, (std::unordered_set<std::string>{"z"}));
 }
+
+TEST_F(TestParser,
+InputStreamStackManipulation) {
+	static std::vector<std::string> input_streams = {
+		"10",
+		"include 0",
+		"30",
+		"40"
+	};
+
+	std::vector<std::unique_ptr<std::stringstream>> inputs;
+
+	Parser<int> p;
+
+	p.token("\\s+");
+	p.token("\\+").symbol("+").precedence(1, Associativity::Left);
+	p.token("\\*").symbol("*").precedence(2, Associativity::Left);
+	p.token("include [0-9]+").action([&](std::string_view str) {
+		auto stream_idx = std::stoi(std::string{str.data() + 8, str.end()});
+		inputs.emplace_back(std::make_unique<std::stringstream>(input_streams[stream_idx]));
+		p.push_input_stream(*inputs.back().get());
+		return 0;
+	});
+	p.token("[0-9]+").symbol("number").action([](std::string_view str) {
+		return std::stoi(std::string{str});
+	});
+	p.end_token().action([&](std::string_view) {
+		p.pop_input_stream();
+		return 0;
+	});
+
+	p.set_start_symbol("E");
+	p.rule("E")
+		.production("E", "+", "E", [](auto&& args) { return args[0] + args[2]; })
+		.production("E", "*", "E", [](auto&& args) { return args[0] * args[2]; })
+		.production("number", [](auto&& args) { return args[0]; });
+
+	EXPECT_TRUE(p.prepare());
+
+	std::stringstream input("include 1 + include 2 * include 3 + 5");
+	auto result = p.parse(input);
+
+	EXPECT_TRUE(result);
+	EXPECT_EQ(result.value(), 1215);
+}

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -642,7 +642,7 @@ InputStreamStackManipulation) {
 	p.token("\\+").symbol("+").precedence(1, Associativity::Left);
 	p.token("\\*").symbol("*").precedence(2, Associativity::Left);
 	p.token("include [0-9]+").action([&](std::string_view str) {
-		auto stream_idx = std::stoi(std::string{str.data() + 8, str.end()});
+		auto stream_idx = std::stoi(std::string{str.begin() + 8, str.end()});
 		inputs.emplace_back(std::make_unique<std::stringstream>(input_streams[stream_idx]));
 		p.push_input_stream(*inputs.back().get());
 		return 0;


### PR DESCRIPTION
* End of input symbol is now properly returned back to parser only when it should
* Parser now has interface to manipulate input streams
* No need to have `\b` at the beginning of fullword tokens since we are anchored at the start
* `html_report.h` is now always included from `pog.h`