### PR TITLE
Added support for accessing all previous symbols in midrule actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# dev
+
+* Midrule actions and all preceding symbols are now accessible from later actions in that rule
+
 # v0.2.1 (2019-09-13)
 
 * Added option `POG_PIC` to build position-independent code

--- a/tests/test_rule_builder.cpp
+++ b/tests/test_rule_builder.cpp
@@ -75,21 +75,17 @@ SingleProductionWithMidruleActions) {
 	);
 	rb.done();
 
-	EXPECT_EQ(grammar.get_symbols().size(), 9u);
-	EXPECT_EQ(grammar.get_rules().size(), 3u);
-	EXPECT_EQ(grammar.get_rules()[0]->to_string(), "func -> _func#0.0 _func#0.1");
-	EXPECT_EQ(grammar.get_rules()[1]->to_string(), "_func#0.0 -> func id");
-	EXPECT_EQ(grammar.get_rules()[2]->to_string(), "_func#0.1 -> { body }");
+	EXPECT_EQ(grammar.get_symbols().size(), 8u);
+	EXPECT_EQ(grammar.get_rules().size(), 2u);
+	EXPECT_EQ(grammar.get_rules()[0]->to_string(), "_func#0.0 -> <eps>");
+	EXPECT_EQ(grammar.get_rules()[1]->to_string(), "func -> func id _func#0.0 { body }");
 	EXPECT_TRUE(grammar.get_rules()[0]->has_action());
 	EXPECT_TRUE(grammar.get_rules()[1]->has_action());
-	EXPECT_TRUE(grammar.get_rules()[2]->has_action());
 
-	EXPECT_EQ(grammar.get_rules()[0]->perform_action(std::vector<int>{}), 0);
-	EXPECT_EQ(grammar.get_rules()[0]->perform_action(std::vector<int>{1, 2, 3}), 3);
-	EXPECT_EQ(grammar.get_rules()[1]->perform_action(std::vector<int>{}), 42);
-	EXPECT_EQ(grammar.get_rules()[1]->perform_action(std::vector<int>{1, 2, 3}), 42);
-	EXPECT_EQ(grammar.get_rules()[2]->perform_action(std::vector<int>{}), 43);
-	EXPECT_EQ(grammar.get_rules()[2]->perform_action(std::vector<int>{1, 2, 3}), 43);
+	EXPECT_EQ(grammar.get_rules()[0]->perform_action(std::vector<int>{}), 42);
+	EXPECT_EQ(grammar.get_rules()[0]->perform_action(std::vector<int>{1, 2, 3}), 42);
+	EXPECT_EQ(grammar.get_rules()[1]->perform_action(std::vector<int>{}), 43);
+	EXPECT_EQ(grammar.get_rules()[1]->perform_action(std::vector<int>{1, 2, 3}), 43);
 }
 
 TEST_F(TestRuleBuilder,
@@ -106,37 +102,29 @@ MultipleProductionsWithMidruleActions) {
 	);
 	rb.done();
 
-	EXPECT_EQ(grammar.get_symbols().size(), 19u);
-	EXPECT_EQ(grammar.get_rules().size(), 7u);
-	EXPECT_EQ(grammar.get_rules()[0]->to_string(), "def -> _def#0.0 _def#0.1 _def#0.2");
-	EXPECT_EQ(grammar.get_rules()[1]->to_string(), "_def#0.0 -> func id");
-	EXPECT_EQ(grammar.get_rules()[2]->to_string(), "_def#0.1 -> ( args )");
-	EXPECT_EQ(grammar.get_rules()[3]->to_string(), "_def#0.2 -> { body }");
-	EXPECT_EQ(grammar.get_rules()[4]->to_string(), "def -> _def#1.0 _def#1.1");
-	EXPECT_EQ(grammar.get_rules()[5]->to_string(), "_def#1.0 -> var id =");
-	EXPECT_EQ(grammar.get_rules()[6]->to_string(), "_def#1.1 -> expr");
+	EXPECT_EQ(grammar.get_symbols().size(), 17u);
+	EXPECT_EQ(grammar.get_rules().size(), 5u);
+	EXPECT_EQ(grammar.get_rules()[0]->to_string(), "_def#0.0 -> <eps>");
+	EXPECT_EQ(grammar.get_rules()[1]->to_string(), "_def#0.1 -> <eps>");
+	EXPECT_EQ(grammar.get_rules()[2]->to_string(), "def -> func id _def#0.0 ( args ) _def#0.1 { body }");
+	EXPECT_EQ(grammar.get_rules()[3]->to_string(), "_def#1.0 -> <eps>");
+	EXPECT_EQ(grammar.get_rules()[4]->to_string(), "def -> var id = _def#1.0 expr");
 	EXPECT_TRUE(grammar.get_rules()[0]->has_action());
 	EXPECT_TRUE(grammar.get_rules()[1]->has_action());
 	EXPECT_TRUE(grammar.get_rules()[2]->has_action());
 	EXPECT_TRUE(grammar.get_rules()[3]->has_action());
 	EXPECT_TRUE(grammar.get_rules()[4]->has_action());
-	EXPECT_TRUE(grammar.get_rules()[5]->has_action());
-	EXPECT_TRUE(grammar.get_rules()[6]->has_action());
 
-	EXPECT_EQ(grammar.get_rules()[0]->perform_action(std::vector<int>{}), 0);
-	EXPECT_EQ(grammar.get_rules()[0]->perform_action(std::vector<int>{1, 2, 3}), 3);
-	EXPECT_EQ(grammar.get_rules()[1]->perform_action(std::vector<int>{}), 42);
-	EXPECT_EQ(grammar.get_rules()[1]->perform_action(std::vector<int>{1, 2, 3}), 42);
-	EXPECT_EQ(grammar.get_rules()[2]->perform_action(std::vector<int>{}), 43);
-	EXPECT_EQ(grammar.get_rules()[2]->perform_action(std::vector<int>{1, 2, 3}), 43);
-	EXPECT_EQ(grammar.get_rules()[3]->perform_action(std::vector<int>{}), 44);
-	EXPECT_EQ(grammar.get_rules()[3]->perform_action(std::vector<int>{1, 2, 3}), 44);
-	EXPECT_EQ(grammar.get_rules()[4]->perform_action(std::vector<int>{}), 0);
-	EXPECT_EQ(grammar.get_rules()[4]->perform_action(std::vector<int>{1, 2, 3}), 3);
-	EXPECT_EQ(grammar.get_rules()[5]->perform_action(std::vector<int>{}), 142);
-	EXPECT_EQ(grammar.get_rules()[5]->perform_action(std::vector<int>{1, 2, 3}), 142);
-	EXPECT_EQ(grammar.get_rules()[6]->perform_action(std::vector<int>{}), 143);
-	EXPECT_EQ(grammar.get_rules()[6]->perform_action(std::vector<int>{1, 2, 3}), 143);
+	EXPECT_EQ(grammar.get_rules()[0]->perform_action(std::vector<int>{}), 42);
+	EXPECT_EQ(grammar.get_rules()[0]->perform_action(std::vector<int>{1, 2, 3}), 42);
+	EXPECT_EQ(grammar.get_rules()[1]->perform_action(std::vector<int>{}), 43);
+	EXPECT_EQ(grammar.get_rules()[1]->perform_action(std::vector<int>{1, 2, 3}), 43);
+	EXPECT_EQ(grammar.get_rules()[2]->perform_action(std::vector<int>{}), 44);
+	EXPECT_EQ(grammar.get_rules()[2]->perform_action(std::vector<int>{1, 2, 3}), 44);
+	EXPECT_EQ(grammar.get_rules()[3]->perform_action(std::vector<int>{}), 142);
+	EXPECT_EQ(grammar.get_rules()[3]->perform_action(std::vector<int>{1, 2, 3}), 142);
+	EXPECT_EQ(grammar.get_rules()[4]->perform_action(std::vector<int>{}), 143);
+	EXPECT_EQ(grammar.get_rules()[4]->perform_action(std::vector<int>{1, 2, 3}), 143);
 }
 
 TEST_F(TestRuleBuilder,


### PR DESCRIPTION
Bison allows access to all midrule actions and all midrule actions have
access to previous ones. This change adds support for this. You can
expect that "args" in rule actions is now filled with all symbols and
you also need to take into account all midrule actions. Value they
return is stored in there.