### PR TITLE
Don't record visited symbols when calculating includes and lookback relations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# dev
+
+* Fixed calulcation of includes and lookback relations when there are more instances of the same symbol inspected
+
 # v0.3.0 (2019-09-22)
 
 * Midrule actions and all preceding symbols are now accessible from later actions in that rule

--- a/include/pog/relations/includes.h
+++ b/include/pog/relations/includes.h
@@ -45,8 +45,6 @@ public:
 		// Iterate over all states in the LR automaton
 		for (const auto& state : Parent::_automaton->get_states())
 		{
-			// Remember what symbols we have already processed for a single state, we don't want to repeat ourselves.
-			std::unordered_set<const SymbolType*> visited_symbols;
 			for (const auto& item : *state.get())
 			{
 				// We are looking for items in form A -> a <*> B b so we are not intersted in final items
@@ -54,11 +52,7 @@ public:
 					continue;
 
 				// Get the symbol right next to <*> in an item
-				// If we already processed it then we can ignore it
 				auto next_symbol = item->get_read_symbol();
-				if (visited_symbols.find(next_symbol) != visited_symbols.end())
-					continue;
-				visited_symbols.insert(next_symbol);
 
 				// If the next symbol is not nonterminal then we are again not interested
 				if (!next_symbol->is_nonterminal())

--- a/include/pog/relations/lookback.h
+++ b/include/pog/relations/lookback.h
@@ -48,19 +48,14 @@ public:
 		// Iterate over all states of LR automaton
 		for (const auto& state : Parent::_automaton->get_states())
 		{
-			// Remember what symbols we have already processed for a single state, we don't want to repeat ourselves.
-			std::unordered_set<const SymbolType*> visited_symbols;
 			for (const auto& item : *state.get())
 			{
 				// We are not interested in items other than in form A -> x <*>
 				if (!item->is_final())
 					continue;
 
-				// We haven't already processed left-hand side symbol of a rule
+				// Get left-hand side symbol of a rule
 				auto prod_symbol = item->get_rule()->get_lhs();
-				if (visited_symbols.find(prod_symbol) != visited_symbols.end())
-					continue;
-				visited_symbols.insert(prod_symbol);
 
 				// Now we'll start backtracking through LR automaton using backtransitions.
 				// We'll basically just go in the different direction of arrows in the automata.

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -845,3 +845,29 @@ EndInputInNonDefaultTokenizerState) {
 		EXPECT_STREQ(e.what(), "Syntax error: Unknown symbol on input, expected one of @end, a, b");
 	}
 }
+
+TEST_F(TestParser,
+IncludesRelationCalulcatedCorrectlyForSameRightHandSifePrefix) {
+	Parser<int> p;
+
+	p.token("a").symbol("a");
+	p.token("b").symbol("b");
+
+	p.set_start_symbol("S");
+	p.rule("S")
+		.production("A");
+	p.rule("A")
+		.production("B", "b")
+		.production("B");
+	p.rule("B")
+		.production("a");
+	EXPECT_TRUE(p.prepare());
+
+	std::stringstream input1("a");
+	auto result = p.parse(input1);
+	EXPECT_TRUE(result);
+
+	std::stringstream input2("ab");
+	result = p.parse(input2);
+	EXPECT_TRUE(result);
+}


### PR DESCRIPTION
It can leave out certain items in states with the same inspected
symbols. This can result in corrupted grammar like the one added in
tests. This grammar failed with syntax error because it didn't expect
that `a` may be followed by `@end`. It only expected `b` as the next
symbol.