### PR TITLE
Clear input stack when calling parse()

### DIFF
--- a/include/pog/parser.h
+++ b/include/pog/parser.h
@@ -137,6 +137,7 @@ public:
 		_tokenizer.enter_state(std::string{decltype(_tokenizer)::DefaultState});
 
 		std::optional<TokenMatchType> token;
+		_tokenizer.clear_input_streams();
 		_tokenizer.push_input_stream(input);
 
 		std::deque<std::pair<std::uint32_t, std::optional<ValueT>>> stack;

--- a/include/pog/tokenizer.h
+++ b/include/pog/tokenizer.h
@@ -128,6 +128,11 @@ public:
 		_input_stack.pop_back();
 	}
 
+	void clear_input_streams()
+	{
+		_input_stack.clear();
+	}
+
 	void global_action(CallbackType&& global_action)
 	{
 		_global_action = std::move(global_action);


### PR DESCRIPTION
Consecutive calls to parse() may have destructive effects when your
input stack wasn't cleared properly in the first run (usually due to the
parsing error).